### PR TITLE
Dockerfile: Fix error running the program

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN git clone https://github.com/TrueBitFoundation/emscripten-module-wrapper \
 RUN git clone https://github.com/mrsmkl/coindrop \
  && cd coindrop \
  && . /emsdk/emsdk_env.sh \
- && emcc -o simple.js simple.c \
+ && emcc -s WASM=1 -o simple.js simple.c \
  && touch output.data \
  && touch input.data \
  && node /emscripten-module-wrapper/prepare2.js simple.js --file input.data --file output.data


### PR DESCRIPTION
Error was:

```
exec:  cp [ 'simple.wasm',
  '/tmp/emscripten-module-wrapper3k5gvlk/simple.wasm' ] /coindrop
error  cp: cannot stat 'simple.wasm': No such file or directory
 [ 'simple.wasm',
  '/tmp/emscripten-module-wrapper3k5gvlk/simple.wasm' ]
cp: cannot stat 'simple.wasm': No such file or directory
```

Applying this PR fixes the problem:

```
Uploaded to IPFS  { path: 'globals.wasm',
  hash: 'QmXjqNDcmHpU2uP6GVL1Wqk9TLJ6j2Q2B9Ps61hnxycZDn',
  size: NaN }
```